### PR TITLE
Bump zmq.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "atom-space-pen-views": "^2.0.5",
     "lodash": "^3.8.0",
     "uuid": "^2.0.1",
-    "zmq": "^2.11.0"
+    "zmq": "^2.11.1"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
Most importantly, this also bumps nan, to ensure Hydrogen builds correctly with iojs (ahem, the future of nodejs), which includes related apps like Electron and the coming release of Atom.