### PR TITLE
Use fix-path in kernel.coffee

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -5,6 +5,10 @@ _ = require 'lodash'
 child_process = require 'child_process'
 uuid = require 'uuid'
 
+fixPath = require 'fix-path'
+
+fixPath()
+
 StatusView = require './status-view'
 
 module.exports =

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.5",
+    "fix-path": "^1.1.0",
     "lodash": "^3.8.0",
     "uuid": "^2.0.1",
     "zmq": "^2.11.1"


### PR DESCRIPTION
Though I have an objection to forcing a new `PATH` on users who set an explicit one in launching Atom directly, this does make it easier for new users.

Addresses #28.

Couple notes:

* this will overwrite any PATH the user set before launching Atom at the command line `PATH=~/myvirtualenv`. That makes virtualenvs and conda environments a no go.
* fix-path forces some node modules on the front unconditionally (on OSX and Linux) if shell-path doesn't return a path back

However, I like the `sh -c echo $PATH` trick here. Wondering if there's a way to find out if Atom was launched via `launchctl`...