### PR TITLE
Fix the type of session to be a string containing a UUID

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -92,7 +92,7 @@ class Kernel
         header = JSON.stringify({
                 msg_id: requestId,
                 username: "",
-                session: 0,
+                session: "00000000-0000-0000-0000-000000000000",
                 msg_type: "execute_request",
                 version: "5.0"
             })
@@ -131,11 +131,11 @@ class Kernel
 
         column = code.length
 
-        console.log "sending competion"
+        console.log "sending completion"
         header = JSON.stringify({
                 msg_id: requestId,
                 username: "",
-                session: 0,
+                session: "00000000-0000-0000-0000-000000000000",
                 msg_type: "complete_request",
                 version: "5.0"
             })

--- a/test.coffee
+++ b/test.coffee
@@ -35,7 +35,7 @@ io_socket.subscribe('')
 header = JSON.stringify({
             msg_id: 0,
             username: "will",
-            session: 0,
+            session: "00000000-0000-0000-0000-000000000000",
             msg_type: "execute_request",
             version: "5.0"
         })


### PR DESCRIPTION
(maybe) fixes #85.

I don't know if this is actually gonna work; I just guessed by searching for `session` in the codebase and put in a null UUID instead of a 0. I don't know how to build or install atom packages so I haven't tested this; hopefully it's just a good basis for someone to come along and test/merge.