### PR TITLE
Update Windows build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Each operating system has their own instruction set. Please read on down to save
 
 #### Windows
 
-- [ZeroMQ for Windows](http://zeromq.org/distro:microsoft-windows)
-- You'll need a compiler! [Visual Studio Community Edition](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx) is recommended.
+- You'll need a compiler! [Visual Studio 2013 Community Edition](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx) is required to build zmq.node.
 - Python (tread on your own or install [Anaconda](http://continuum.io/downloads))
 - [IPython notebook](http://ipython.org/install.html) - If you installed Anaconda, you're already done
 


### PR DESCRIPTION
- Changed the required compiler to VS 2013 as node zmq requires the v120
build tools.
- Removed required zmq install.

Visual Studio 2015 Community doesn't seem to provide the required build tools for node-gyp required by zmq.node. 
Tested on windows 10 with fresh install of atom.