### PR TITLE
Result scrolling

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -130,8 +130,9 @@ class ResultView
                 @resultType = 'text'
                 container.innerText = container.innerText + result.data
 
-                if /\r|\n/.exec(container.innerText.trim())
-                    @setMultiline(true)
+                if /(\\n|\r|\n)/.exec container.innerText.trim()
+                    container.innerText = container.innerText.replace /\\n/g, "\n"
+                    @setMultiline true
             else
                 console.error "Unrecognized result:", result
 

--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -10,6 +10,7 @@ class ResultView
 
         @outputContainer = document.createElement('div')
         @outputContainer.classList.add('bubble-output-container')
+        @outputContainer.onmousewheel = (e) -> e.stopPropagation()
         @element.appendChild(@outputContainer)
 
         @resultContainer = document.createElement('div')
@@ -130,9 +131,11 @@ class ResultView
                 @resultType = 'text'
                 container.innerText = container.innerText + result.data
 
-                if /(\\n|\r|\n)/.exec container.innerText.trim()
-                    container.innerText = container.innerText.replace /\\n/g, "\n"
-                    @setMultiline true
+                if /(\\n|\r|\n)/.exec(container.innerText.trim()) \
+                or container.offsetWidth > 500 \
+                or container.offsetHeight > 500
+                  container.innerText = container.innerText.replace /\\n/g, "\n"
+                  @setMultiline true
             else
                 console.error "Unrecognized result:", result
 

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -79,6 +79,7 @@
 
         .bubble-output-container {
             padding: 3px;
+            overflow: scroll;
         }
 
         .rich-close-button::before {


### PR DESCRIPTION
1. No hardwrap, only scrolling if content view is bigger than 500 px at any dimension
2. 500 was hardcoded because i don't know how to get maxHeight from .bubble-output-container
3. Replacing of escaped \n was added because of:
*If I execute language print variable command (print in python, console.log,...) I get multiline answer with any kernel. But when I execute declaration of variable with multiline text returned answer contains escaped newlines which by design is ok, but looks ugly in hydrogen*
4. ```overflow: scroll``` adds additional padding in all result views with/without scrollbars, maybe change it dynamically? But I didn't see advantages


All of statements can be discussed